### PR TITLE
In case of sub-domain delegation NS record should be kept during Zone import.

### DIFF
--- a/designate/central/service.py
+++ b/designate/central/service.py
@@ -2677,8 +2677,12 @@ class Service(service.RPCService, service.Service):
                     zone.__setattr__('attributes', attr)
 
                 for rrset in list(zone.recordsets):
-                    if rrset.type in ('NS', 'SOA'):
+                    if rrset.type == 'SOA':
                         zone.recordsets.remove(rrset)
+                    # the base ns record will be replaced 
+                    if rrset.type == 'NS' and rrset.name == zone.name:
+                        zone.recordsets.remove(rrset)
+
 
             except dnszone.UnknownOrigin:
                 zone_import.message = ('The $ORIGIN statement is required and'

--- a/designate/tests/test_api/test_v2/test_import_export.py
+++ b/designate/tests/test_api/test_v2/test_import_export.py
@@ -133,7 +133,6 @@ class APIV2ZoneImportExportTest(ApiV2TestCase):
         # Delete NS records, since they won't be the same
         imported.delete_rdataset(imported.origin, 'NS')
         exported.delete_rdataset(exported.origin, 'NS')
-        imported.delete_rdataset('delegation', 'NS')
         self.assertEqual(imported, exported)
 
     def test_import_with_pool_id(self):


### PR DESCRIPTION
Previously, Designate simply deleted all NS and SOA records during import,
so sub-domain records were lost.