### PR TITLE
Attribute filter should also take pool_id into account.

### DIFF
--- a/designate/scheduler/filters/attribute_filter.py
+++ b/designate/scheduler/filters/attribute_filter.py
@@ -15,6 +15,7 @@ import six
 from oslo_log import log as logging
 from oslo_utils.strutils import bool_from_string
 
+from designate import policy
 from designate import exceptions
 from designate.objects import PoolList
 from designate.scheduler.filters import base
@@ -59,7 +60,21 @@ class AttributeFilter(base.Filter):
     def filter(self, context, pools, zone):
 
         try:
-            zone_attributes = zone.attributes.to_dict()
+            # if pool_id was given - schedule there
+            pool_id = zone.attributes.get('pool_id')
+            if pool_id:
+                try:
+                    pool = self.storage.get_pool(context, pool_id)
+                except Exception:
+                    return PoolList()
+                policy.check('zone_create_forced_pool', context, pool)
+                if pool in pools:
+                    pools = PoolList()
+                    pools.append(pool)
+                    return pools
+            else:
+                # otherwise - do attributes check as usual
+                zone_attributes = zone.attributes.to_dict()
         except exceptions.RelationNotLoaded:
             zone_attributes = {}
 


### PR DESCRIPTION
As discussed earlier, attribute filter should take 'pool_id' if it was specified.