### PR TITLE
Allow to set 'description_field_mandatory' in designate.conf

### DIFF
--- a/designate/api/__init__.py
+++ b/designate/api/__init__.py
@@ -27,6 +27,8 @@ api_opts = [
                help='Number of api greenthreads to spawn'),
     cfg.BoolOpt('enable-host-header', default=False,
                help='Enable host request headers'),
+    cfg.BoolOpt('description-field-mandatory', default=False,
+               help='Make Zone description fields mandatory'),
     cfg.StrOpt('api-base-uri', default='http://127.0.0.1:9001/',
                help='the url used as the base for all API responses,'
                     'This should consist of the scheme (http/https),'

--- a/designate/objects/zone.py
+++ b/designate/objects/zone.py
@@ -12,11 +12,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from oslo_config import cfg
+
 from designate import utils
 from designate import exceptions
 from designate.objects import base
 from designate.objects.validation_error import ValidationError
 from designate.objects.validation_error import ValidationErrorList
+
+cfg.CONF.import_opt('description_field_mandatory', 'designate.api', group='service:api')
 
 
 class Zone(base.DictObjectMixin, base.SoftDeleteObjectMixin,
@@ -225,6 +229,14 @@ class Zone(base.DictObjectMixin, base.SoftDeleteObjectMixin,
                 e.validator_value = 'email'
                 e.message = "'email' is a required property"
                 errors.append(e)
+            if cfg.CONF['service:api'].description_field_mandatory:
+                if self.description is None:
+                    e = ValidationError()
+                    e.path = ['type']
+                    e.validator = 'required'
+                    e.validator_value = 'description'
+                    e.message = "'description' is a required property"
+                    errors.append(e)
             self._raise(errors)
 
         try:
@@ -246,6 +258,15 @@ class Zone(base.DictObjectMixin, base.SoftDeleteObjectMixin,
                         e.message = "'%s' can't be specified when type is " \
                             "SECONDARY" % i
                         errors.append(e)
+
+                if cfg.CONF['service:api'].description_field_mandatory:
+                    if self.description is None:
+                        e = ValidationError()
+                        e.path = ['type']
+                        e.validator = 'required'
+                        e.validator_value = 'description'
+                        e.message = "'description' is a required property"
+
                 self._raise(errors)
 
             super(Zone, self).validate()

--- a/etc/designate/designate.conf.sample
+++ b/etc/designate/designate.conf.sample
@@ -97,6 +97,9 @@ debug = False
 # Enable host request headers
 #enable_host_header = False
 
+# Make Zone description field mandatory
+#description_field_mandatory = False
+
 # The base uri used in responses
 #api_base_uri = 'http://127.0.0.1:9001/'
 


### PR DESCRIPTION
 to make 'description' field mandatory during zone creation.