### PR TITLE
Delete service_status entry on service.stop()

### DIFF
--- a/designate/agent/service.py
+++ b/designate/agent/service.py
@@ -28,6 +28,7 @@ from oslo_config import cfg
 
 from designate import utils
 from designate import dnsutils
+from designate import heartbeat_emitter
 from designate import service
 from designate.agent import handler
 from designate.backend import agent_backend
@@ -54,13 +55,17 @@ class Service(service.Service):
 
         backend_driver = cfg.CONF['service:agent'].backend_driver
         self.backend = agent_backend.get_backend(backend_driver, self)
+        self.heartbeat = heartbeat_emitter.get_heartbeat_emitter(
+            self.service_name)
 
     def start(self):
         super(Service, self).start()
         self.dns_service.start()
         self.backend.start()
+        self.heartbeat.start()
 
     def stop(self, graceful=True):
+        self.heartbeat.stop()
         self.dns_service.stop()
         self.backend.stop()
         super(Service, self).stop(graceful)

--- a/designate/api/service.py
+++ b/designate/api/service.py
@@ -18,6 +18,7 @@ from oslo_log import log as logging
 from paste import deploy
 
 from designate import exceptions
+from designate import heartbeat_emitter
 from designate import service
 from designate import utils
 
@@ -31,11 +32,15 @@ class Service(service.WSGIService):
             self.service_name,
             cfg.CONF['service:api'].listen,
         )
+        self.heartbeat = heartbeat_emitter.get_heartbeat_emitter(
+            self.service_name)
 
     def start(self):
         super(Service, self).start()
+        self.heartbeat.start()
 
     def stop(self, graceful=True):
+        self.heartbeat.stop()
         super(Service, self).stop(graceful)
 
     @property

--- a/designate/central/rpcapi.py
+++ b/designate/central/rpcapi.py
@@ -516,3 +516,7 @@ class CentralAPI(object):
     def update_service_status(self, context, service_status):
         self.client.cast(context, 'update_service_status',
                          service_status=service_status)
+
+    def delete_service_status(self, context, service_status):
+        self.client.cast(context, 'delete_service_status',
+                         service_status=service_status)

--- a/designate/cmd/agent.py
+++ b/designate/cmd/agent.py
@@ -19,7 +19,6 @@ from oslo_log import log as logging
 from oslo_reports import guru_meditation_report as gmr
 
 import designate.conf
-from designate import heartbeat_emitter
 from designate import hookpoints
 from designate import service
 from designate import utils
@@ -39,7 +38,5 @@ def main():
     hookpoints.log_hook_setup()
 
     server = agent_service.Service()
-    heartbeat = heartbeat_emitter.get_heartbeat_emitter(server.service_name)
     service.serve(server, workers=CONF['service:agent'].workers)
-    heartbeat.start()
     service.wait()

--- a/designate/cmd/api.py
+++ b/designate/cmd/api.py
@@ -20,7 +20,6 @@ from oslo_log import log as logging
 from oslo_reports import guru_meditation_report as gmr
 
 import designate.conf
-from designate import heartbeat_emitter
 from designate import hookpoints
 from designate import service
 from designate import utils
@@ -41,7 +40,5 @@ def main():
     hookpoints.log_hook_setup()
 
     server = api_service.Service()
-    heartbeat = heartbeat_emitter.get_heartbeat_emitter(server.service_name)
     service.serve(server, workers=CONF['service:api'].workers)
-    heartbeat.start()
     service.wait()

--- a/designate/cmd/central.py
+++ b/designate/cmd/central.py
@@ -19,7 +19,6 @@ from oslo_log import log as logging
 from oslo_reports import guru_meditation_report as gmr
 
 import designate.conf
-from designate import heartbeat_emitter
 from designate import hookpoints
 from designate import service
 from designate import utils
@@ -39,8 +38,5 @@ def main():
     hookpoints.log_hook_setup()
 
     server = central_service.Service()
-    heartbeat = heartbeat_emitter.get_heartbeat_emitter(server.service_name,
-                                                        rpc_api=server)
     service.serve(server, workers=CONF['service:central'].workers)
-    heartbeat.start()
     service.wait()

--- a/designate/cmd/mdns.py
+++ b/designate/cmd/mdns.py
@@ -19,7 +19,6 @@ from oslo_log import log as logging
 from oslo_reports import guru_meditation_report as gmr
 
 import designate.conf
-from designate import heartbeat_emitter
 from designate import hookpoints
 from designate import service
 from designate import utils
@@ -39,7 +38,5 @@ def main():
     hookpoints.log_hook_setup()
 
     server = mdns_service.Service()
-    heartbeat = heartbeat_emitter.get_heartbeat_emitter(server.service_name)
     service.serve(server, workers=CONF['service:mdns'].workers)
-    heartbeat.start()
     service.wait()

--- a/designate/cmd/producer.py
+++ b/designate/cmd/producer.py
@@ -19,7 +19,6 @@ from oslo_log import log as logging
 from oslo_reports import guru_meditation_report as gmr
 
 import designate.conf
-from designate import heartbeat_emitter
 from designate import hookpoints
 from designate import service
 from designate import utils
@@ -39,7 +38,5 @@ def main():
     hookpoints.log_hook_setup()
 
     server = producer_service.Service()
-    heartbeat = heartbeat_emitter.get_heartbeat_emitter(server.service_name)
     service.serve(server, workers=CONF['service:producer'].workers)
-    heartbeat.start()
     service.wait()

--- a/designate/cmd/sink.py
+++ b/designate/cmd/sink.py
@@ -19,7 +19,6 @@ from oslo_log import log as logging
 from oslo_reports import guru_meditation_report as gmr
 
 import designate.conf
-from designate import heartbeat_emitter
 from designate import hookpoints
 from designate import service
 from designate import utils
@@ -39,7 +38,5 @@ def main():
     hookpoints.log_hook_setup()
 
     server = sink_service.Service()
-    heartbeat = heartbeat_emitter.get_heartbeat_emitter(server.service_name)
     service.serve(server, workers=CONF['service:sink'].workers)
-    heartbeat.start()
     service.wait()

--- a/designate/cmd/worker.py
+++ b/designate/cmd/worker.py
@@ -19,7 +19,6 @@ from oslo_log import log as logging
 from oslo_reports import guru_meditation_report as gmr
 
 import designate.conf
-from designate import heartbeat_emitter
 from designate import hookpoints
 from designate import service
 from designate import utils
@@ -39,7 +38,5 @@ def main():
     hookpoints.log_hook_setup()
 
     server = worker_service.Service()
-    heartbeat = heartbeat_emitter.get_heartbeat_emitter(server.service_name)
     service.serve(server, workers=CONF['service:worker'].workers)
-    heartbeat.start()
     service.wait()

--- a/designate/common/policies/service_status.py
+++ b/designate/common/policies/service_status.py
@@ -40,7 +40,12 @@ deprecated_update_service_status = policy.DeprecatedRule(
     deprecated_reason=DEPRECATED_REASON,
     deprecated_since=versionutils.deprecated.WALLABY
 )
-
+deprecated_delete_service_status = policy.DeprecatedRule(
+    "delete_service_status",
+    base.RULE_ADMIN,
+    deprecated_reason=DEPRECATED_REASON,
+    deprecated_since=versionutils.deprecated.WALLABY
+)
 
 rules = [
     policy.DocumentedRuleDefault(
@@ -74,6 +79,12 @@ rules = [
         check_str=base.SYSTEM_ADMIN,
         scope_types=['system'],
         deprecated_rule=deprecated_update_service_status
+    ),
+    policy.RuleDefault(
+        name="delete_service_status",
+        check_str=base.SYSTEM_ADMIN,
+        scope_types=['system'],
+        deprecated_rule=deprecated_delete_service_status
     )
 ]
 

--- a/designate/mdns/service.py
+++ b/designate/mdns/service.py
@@ -17,6 +17,7 @@ from oslo_config import cfg
 from oslo_log import log as logging
 
 from designate import dnsutils
+from designate import heartbeat_emitter
 from designate import service
 from designate import storage
 from designate import utils
@@ -49,12 +50,16 @@ class Service(service.RPCService):
             cfg.CONF['service:mdns'].tcp_backlog,
             cfg.CONF['service:mdns'].tcp_recv_timeout,
         )
+        self.heartbeat = heartbeat_emitter.get_heartbeat_emitter(
+            self.service_name)
 
     def start(self):
         super(Service, self).start()
         self.dns_service.start()
+        self.heartbeat.start()
 
     def stop(self, graceful=True):
+        self.heartbeat.stop()
         self.dns_service.stop()
         super(Service, self).stop(graceful)
 

--- a/designate/storage/base.py
+++ b/designate/storage/base.py
@@ -843,3 +843,12 @@ class Storage(DriverPlugin, metaclass=abc.ABCMeta):
         :param context: RPC Context.
         :param service_status: Set the status for a service.
         """
+
+    @abc.abstractmethod
+    def delete_service_status(self, context, service_status):
+        """
+        Delete the Service.
+
+        :param context: RPC Context.
+        :param service_status: Service status object for delete
+        """

--- a/designate/storage/impl_sqlalchemy/__init__.py
+++ b/designate/storage/impl_sqlalchemy/__init__.py
@@ -1895,6 +1895,11 @@ class SQLAlchemyStorage(sqlalchemy_base.SQLAlchemy, storage_base.Storage):
             exceptions.DuplicateServiceStatus,
             exceptions.ServiceStatusNotFound)
 
+    def delete_service_status(self, context, service_status):
+        return self._delete(
+            context, tables.service_status, service_status,
+            exceptions.ServiceStatusNotFound)
+
     # diagnostics
     def ping(self, context):
         start_time = time.time()


### PR DESCRIPTION
Heartbeat emission within designate services does not delete DB status entries on service stop which results in lot of service_status entries in DB reported under 'openstack dns service list'. The service which were stopped on any pod and started on another pod(with another host) should only have new entry in DB.