### PR TITLE
Fail to create recordset if record contain underscore

### DIFF
--- a/designate/central/service.py
+++ b/designate/central/service.py
@@ -1486,6 +1486,10 @@ class Service(service.RPCService):
         if zone.action == 'DELETE':
             raise exceptions.BadRequest('Can not update a deleting zone')
 
+        if '_' in recordset.name:
+            raise exceptions.BadRequest(
+                'record name should not contain underscore')
+
         target = {
             'zone_id': zone_id,
             'zone_name': zone.name,

--- a/designate/tests/test_central/test_service.py
+++ b/designate/tests/test_central/test_service.py
@@ -1492,6 +1492,22 @@ class CentralServiceTest(CentralTestCase):
 
         self.assertEqual(exceptions.InvalidRecordSetLocation, exc.exc_info[0])
 
+    def test_create_invalid_recordset_name(self):
+        zone = self.create_zone()
+
+        values = dict(
+            name='ww_w.%s' % zone['name'],
+            type='A'
+        )
+
+        exc = self.assertRaises(rpc_dispatcher.ExpectedException,
+                                self.central_service.create_recordset,
+                                self.admin_context,
+                                zone['id'],
+                                recordset=objects.RecordSet.from_dict(values))
+
+        self.assertEqual(exceptions.BadRequest, exc.exc_info[0])
+
     def test_create_invalid_recordset_location_cname_sharing(self):
         zone = self.create_zone()
         expected = self.create_recordset(zone)


### PR DESCRIPTION
Underscore characters are not permitted in domain names in accordance with RFC 1035. Fix it in designate.