### PR TITLE
Move to a batch model for incrementing serial

### DIFF
--- a/designate/central/rpcapi.py
+++ b/designate/central/rpcapi.py
@@ -66,8 +66,9 @@ class CentralAPI(object):
         6.2 - Changed 'find_recordsets' method args
         6.3 - Add methods for shared zones
         6.4 - Add Zone move method
+        6.5 - Add increment_zone_serial
     """
-    RPC_API_VERSION = '6.4'
+    RPC_API_VERSION = '6.5'
 
     # This allows us to mark some methods as not logged.
     # This can be for a few reasons - some methods my not actually call over
@@ -80,7 +81,7 @@ class CentralAPI(object):
 
         target = messaging.Target(topic=self.topic,
                                   version=self.RPC_API_VERSION)
-        self.client = rpc.get_client(target, version_cap='6.4')
+        self.client = rpc.get_client(target, version_cap='6.5')
 
     @classmethod
     def get_instance(cls):
@@ -146,6 +147,9 @@ class CentralAPI(object):
         return self.client.call(context, 'count_tenants')
 
     # Zone Methods
+    def increment_zone_serial(self, context, zone):
+        return self.client.call(context, 'increment_zone_serial', zone=zone)
+
     def create_zone(self, context, zone):
         return self.client.call(context, 'create_zone', zone=zone)
 

--- a/designate/conf/producer.py
+++ b/designate/conf/producer.py
@@ -20,6 +20,11 @@ PRODUCER_GROUP = cfg.OptGroup(
     title='Configuration for Producer Service'
 )
 
+PRODUCER_TASK_INCREMENT_SERIAL_GROUP = cfg.OptGroup(
+    name='producer_task:increment_serial',
+    title='Configuration for Producer Task: Increment Serial'
+)
+
 PRODUCER_TASK_DELAYED_NOTIFY_GROUP = cfg.OptGroup(
     name='producer_task:delayed_notify',
     title='Configuration for Producer Task: Delayed Notify'
@@ -60,6 +65,15 @@ PRODUCER_OPTS = [
                 deprecated_reason='Migrated to designate-worker'),
     cfg.StrOpt('topic', default='producer',
                help='RPC topic name for producer'),
+]
+
+PRODUCER_TASK_INCREMENT_SERIAL_OPTS = [
+    cfg.IntOpt('interval', default=5,
+               help='Run interval in seconds'),
+    cfg.IntOpt('per_page', default=100,
+               help='Default amount of results returned per page'),
+    cfg.IntOpt('batch_size', default=100,
+               help='How many zones to increment serial for on each run'),
 ]
 
 PRODUCER_TASK_DELAYED_NOTIFY_OPTS = [
@@ -111,6 +125,9 @@ def register_opts(conf):
     conf.register_group(PRODUCER_TASK_DELAYED_NOTIFY_GROUP)
     conf.register_opts(PRODUCER_TASK_DELAYED_NOTIFY_OPTS,
                        group=PRODUCER_TASK_DELAYED_NOTIFY_GROUP)
+    conf.register_group(PRODUCER_TASK_INCREMENT_SERIAL_GROUP)
+    conf.register_opts(PRODUCER_TASK_INCREMENT_SERIAL_OPTS,
+                       group=PRODUCER_TASK_INCREMENT_SERIAL_GROUP)
     conf.register_group(PRODUCER_TASK_PERIODIC_EXISTS_GROUP)
     conf.register_opts(PRODUCER_TASK_PERIODIC_EXISTS_OPTS,
                        group=PRODUCER_TASK_PERIODIC_EXISTS_GROUP)

--- a/designate/objects/zone.py
+++ b/designate/objects/zone.py
@@ -66,6 +66,7 @@ class Zone(base.DesignateObject, base.DictObjectMixin,
                                  ),
         'transferred_at': fields.DateTimeField(nullable=True, read_only=False),
         'delayed_notify': fields.BooleanField(nullable=True),
+        'increment_serial': fields.BooleanField(nullable=True),
     }
 
     STRING_KEYS = [

--- a/designate/producer/tasks.py
+++ b/designate/producer/tasks.py
@@ -231,7 +231,6 @@ class PeriodicGenerateDelayedNotifyTask(PeriodicTask):
         Call Worker to emit NOTIFY transactions,
         Reset the flag.
         """
-        pstart, pend = self._my_range()
 
         ctxt = context.DesignateContext.get_admin_context()
         ctxt.all_tenants = True
@@ -241,6 +240,7 @@ class PeriodicGenerateDelayedNotifyTask(PeriodicTask):
         # There's an index on delayed_notify.
         criterion = self._filter_between('shard')
         criterion['delayed_notify'] = True
+        criterion['increment_serial'] = False
         zones = self.central_api.find_zones(
             ctxt,
             criterion,
@@ -249,19 +249,69 @@ class PeriodicGenerateDelayedNotifyTask(PeriodicTask):
             sort_dir='asc',
         )
 
-        LOG.debug(
-            "Performing delayed NOTIFY for %(start)s to %(end)s: %(n)d",
-            {
-                'start': pstart,
-                'end': pend,
-                'n': len(zones)
-            }
-        )
-
         for zone in zones:
+            if zone.action == 'NONE':
+                zone.action = 'UPDATE'
+                zone.status = 'PENDING'
+            elif zone.action == 'DELETE':
+                LOG.debug(
+                    'Skipping delayed NOTIFY for %(id)s being DELETED',
+                    {
+                        'id': zone.id,
+                    }
+                )
+                continue
             self.zone_api.update_zone(ctxt, zone)
             zone.delayed_notify = False
             self.central_api.update_zone(ctxt, zone)
+
+
+class PeriodicIncrementSerialTask(PeriodicTask):
+    __plugin_name__ = 'increment_serial'
+
+    def __init__(self):
+        super(PeriodicIncrementSerialTask, self).__init__()
+
+    def __call__(self):
+        ctxt = context.DesignateContext.get_admin_context()
+        ctxt.all_tenants = True
+
+        # Select zones where "increment_serial" is set and starting from the
+        # oldest "updated_at".
+        # There's an index on increment_serial.
+        criterion = self._filter_between('shard')
+        criterion['increment_serial'] = True
+        zones = self.central_api.find_zones(
+            ctxt,
+            criterion,
+            limit=CONF[self.name].batch_size,
+            sort_key='updated_at',
+            sort_dir='asc',
+        )
+        for zone in zones:
+            if zone.action == 'DELETE':
+                LOG.debug(
+                    'Skipping increment serial for %(id)s being DELETED',
+                    {
+                        'id': zone.id,
+                    }
+                )
+                continue
+
+            serial = self.central_api.increment_zone_serial(ctxt, zone)
+            LOG.debug(
+                'Incremented serial for %(id)s to %(serial)d',
+                {
+                    'id': zone.id,
+                    'serial': serial,
+                }
+            )
+            if not zone.delayed_notify:
+                # Notify the backend.
+                if zone.action == 'NONE':
+                    zone.action = 'UPDATE'
+                    zone.status = 'PENDING'
+                self.worker_api.update_zone(ctxt, zone)
 
 
 class WorkerPeriodicRecovery(PeriodicTask):

--- a/designate/sqlalchemy/base.py
+++ b/designate/sqlalchemy/base.py
@@ -206,7 +206,7 @@ class SQLAlchemy(object, metaclass=abc.ABCMeta):
         # Ensure the Object is valid
         # obj.validate()
 
-        values = obj.obj_get_changes()
+        values = dict(obj)
 
         if skip_values is not None:
             for skip_value in skip_values:
@@ -219,7 +219,7 @@ class SQLAlchemy(object, metaclass=abc.ABCMeta):
         query = table.insert()
 
         try:
-            resultproxy = self.session.execute(query, [dict(values)])
+            resultproxy = self.session.execute(query, [values])
         except oslo_db_exception.DBDuplicateEntry:
             msg = "Duplicate %s" % obj.obj_name()
             raise exc_dup(msg)

--- a/designate/storage/base.py
+++ b/designate/storage/base.py
@@ -224,6 +224,15 @@ class Storage(DriverPlugin, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
+    def increment_serial(self, context, zone_id):
+        """
+        Increment serial of a Zone
+
+        :param context: RPC Context.
+        :param zone_id: ID of the Zone.
+        """
+
+    @abc.abstractmethod
     def create_zone(self, context, zone):
         """
         Create a new Zone.

--- a/designate/storage/impl_sqlalchemy/__init__.py
+++ b/designate/storage/impl_sqlalchemy/__init__.py
@@ -17,6 +17,7 @@ import time
 
 from oslo_log import log as logging
 from oslo_utils.secretutils import md5
+from oslo_utils import timeutils
 from sqlalchemy import select, distinct, func, outerjoin
 from sqlalchemy.sql.expression import or_, and_
 
@@ -451,6 +452,18 @@ class SQLAlchemyStorage(sqlalchemy_base.SQLAlchemy, storage_base.Storage):
             self.session.execute(recordsets_query)
 
         return updated_zone
+
+    def increment_serial(self, context, zone_id):
+        """Increment the zone's serial number.
+        """
+        new_serial = timeutils.utcnow_ts()
+        query = tables.zones.update().where(
+            tables.zones.c.id == zone_id).values(
+            {'serial': new_serial, 'increment_serial': False}
+        )
+        self.session.execute(query)
+        LOG.debug('Incremented zone serial for %s to %d', zone_id, new_serial)
+        return new_serial
 
     def delete_zone(self, context, zone_id):
         """

--- a/designate/storage/impl_sqlalchemy/migrate_repo/versions/105_add_increment_serial_column.py
+++ b/designate/storage/impl_sqlalchemy/migrate_repo/versions/105_add_increment_serial_column.py
@@ -1,0 +1,35 @@
+# Copyright 2015 Hewlett-Packard Development Company, L.P.
+#
+# Author: Federico Ceratto <federico.ceratto@hpe.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# See https://blueprints.launchpad.net/nova/+spec/backportable-db-migrations
+# http://lists.openstack.org/pipermail/openstack-dev/2013-March/006827.html
+
+from oslo_log import log as logging
+from sqlalchemy import Boolean
+from sqlalchemy.schema import Column, MetaData, Table, Index
+
+LOG = logging.getLogger(__name__)
+meta = MetaData()
+
+
+def upgrade(migrate_engine):
+    LOG.info("Adding boolean column increment_serial to table 'zones'")
+    meta.bind = migrate_engine
+    zones_table = Table('zones', meta, autoload=True)
+    col = Column('increment_serial', Boolean(), default=False)
+    col.create(zones_table)
+    index = Index('increment_serial', zones_table.c.increment_serial)
+    index.create(migrate_engine)

--- a/designate/storage/impl_sqlalchemy/tables.py
+++ b/designate/storage/impl_sqlalchemy/tables.py
@@ -139,6 +139,7 @@ zones = Table('zones', metadata,
     Column('pool_id', UUID, default=None, nullable=True),
     Column('reverse_name', String(255), nullable=False),
     Column('delayed_notify', Boolean, default=False),
+    Column('increment_serial', Boolean, default=False),
 
     UniqueConstraint('name', 'deleted', 'pool_id', name='unique_zone_name'),
     ForeignKeyConstraint(['parent_zone_id'],

--- a/designate/tests/test_api/test_v2/test_recordsets.py
+++ b/designate/tests/test_api/test_v2/test_recordsets.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 import oslo_messaging as messaging
 from oslo_log import log as logging
+from oslo_utils import timeutils
 
 from designate import exceptions
 from designate.central import service as central_service
@@ -384,10 +385,8 @@ class ApiV2RecordSetsTest(ApiV2TestCase):
         self.client.delete('/zones/%s' % zone['id'], status=202)
 
         # Simulate the zone having been deleted on the backend
-        zone_serial = self.central_service.get_zone(
-            self.admin_context, zone['id']).serial
         self.central_service.update_status(
-            self.admin_context, zone['id'], "SUCCESS", zone_serial)
+            self.admin_context, zone['id'], 'SUCCESS', timeutils.utcnow_ts())
 
         # Check that we get a zone_not_found error
         self._assert_exception('zone_not_found', 404, self.client.get, url)

--- a/designate/tests/test_api/test_v2/test_zones.py
+++ b/designate/tests/test_api/test_v2/test_zones.py
@@ -372,7 +372,6 @@ class ApiV2ZonesTest(ApiV2TestCase):
         # Check the values returned are what we expect
         self.assertIn('id', response.json)
         self.assertIsNotNone(response.json['updated_at'])
-        self.assertEqual(new_serial, response.json['serial'])
 
     def test_update_zone_invalid_id(self):
         self._assert_invalid_uuid(self.client.patch_json, '/zones/%s')

--- a/designate/tests/test_storage/test_sqlalchemy.py
+++ b/designate/tests/test_storage/test_sqlalchemy.py
@@ -96,6 +96,7 @@ class SqlalchemyStorageTest(StorageTestCase, TestCase):
             },
             "zones": {
                 "delayed_notify": "CREATE INDEX delayed_notify ON zones (delayed_notify)",  # noqa
+                "increment_serial": "CREATE INDEX increment_serial ON zones (increment_serial)",  # noqa
                 "reverse_name_deleted": "CREATE INDEX reverse_name_deleted ON zones (reverse_name, deleted)",  # noqa
                 "zone_created_at": "CREATE INDEX zone_created_at ON zones (created_at)",  # noqa
                 "zone_deleted": "CREATE INDEX zone_deleted ON zones (deleted)",

--- a/designate/tests/unit/test_central/test_basic.py
+++ b/designate/tests/unit/test_central/test_basic.py
@@ -179,6 +179,7 @@ class MockRecordSet(object):
     ttl = 1
     type = "PRIMARY"
     serial = 123
+    records = []
 
     def obj_attr_is_set(self, n):
         if n == 'records':
@@ -431,7 +432,9 @@ class CentralServiceTestCase(CentralBasic):
         central_service._is_valid_ttl = mock.Mock()
 
         central_service.storage.create_recordset = mock.Mock(return_value='rs')
-        central_service._update_zone_in_storage = mock.Mock()
+        central_service._update_zone_in_storage = mock.Mock(
+            return_value=Mockzone()
+        )
 
         recordset = mock.Mock()
         recordset.obj_attr_is_set.return_value = True
@@ -453,7 +456,9 @@ class CentralServiceTestCase(CentralBasic):
         self.service._is_valid_ttl = mock.Mock()
 
         self.service.storage.create_recordset = mock.Mock(return_value='rs')
-        self.service._update_zone_in_storage = mock.Mock()
+        self.service._update_zone_in_storage = mock.Mock(
+            return_value=Mockzone()
+        )
 
         # NOTE(thirose): Since this is a race condition we assume that
         #  we will hit it if we try to do the operations in a loop 100 times.
@@ -1526,8 +1531,6 @@ class CentralZoneTestCase(CentralBasic):
             self.service.delete_recordset(self.context,
                 CentralZoneTestCase.zone__id_2,
                 CentralZoneTestCase.recordset__id)
-            self.assertTrue(
-                self.service.zone_api.update_zone.called)
 
         self.assertTrue(
             self.service._delete_recordset_in_storage.called)
@@ -1544,6 +1547,7 @@ class CentralZoneTestCase(CentralBasic):
                     action='',
                     status='',
                     serial=0,
+                    increment_serial=False,
                 )
             ])
         )
@@ -1553,7 +1557,7 @@ class CentralZoneTestCase(CentralBasic):
         self.assertEqual(1, len(rs.records))
         self.assertEqual('DELETE', rs.records[0].action)
         self.assertEqual('PENDING', rs.records[0].status)
-        self.assertEqual(1, rs.records[0].serial)
+        self.assertTrue(rs.records[0].serial, 1)
 
     def test_delete_recordset_in_storage_no_increment_serial(self):
         self.service._update_zone_in_storage = mock.Mock()

--- a/designate/tests/unit/test_utils.py
+++ b/designate/tests/unit/test_utils.py
@@ -17,7 +17,6 @@ import oslotest.base
 from oslo_concurrency import processutils
 from oslo_config import cfg
 from oslo_config import fixture as cfg_fixture
-from oslo_utils import timeutils
 
 from designate import exceptions
 from designate import utils
@@ -250,22 +249,6 @@ class TestUtils(oslotest.base.BaseTestCase):
         )
         mock_open.assert_called_once_with(output_path, 'w')
         mock_open().write.assert_called_once_with('Hello World')
-
-    @mock.patch.object(timeutils, 'utcnow_ts')
-    def test_increment_serial_lower_than_ts(self, mock_utcnow_ts):
-        mock_utcnow_ts.return_value = 1561698354
-
-        ret_serial = utils.increment_serial(serial=1)
-
-        self.assertEqual(1561698354, ret_serial)
-
-    @mock.patch.object(timeutils, 'utcnow_ts')
-    def test_increment_serial_higher_than_ts(self, mock_utcnow_ts):
-        mock_utcnow_ts.return_value = 1561698354
-
-        ret_serial = utils.increment_serial(serial=1561698354 * 2)
-
-        self.assertEqual(1561698354 * 2 + 1, ret_serial)
 
     def test_is_uuid_like(self):
         self.assertTrue(

--- a/designate/utils.py
+++ b/designate/utils.py
@@ -26,7 +26,6 @@ from oslo_config import cfg
 from oslo_concurrency import processutils
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
-from oslo_utils import timeutils
 from oslo_utils import uuidutils
 from oslo_utils.netutils import is_valid_ipv6
 
@@ -132,16 +131,6 @@ def execute(*cmd, **kw):
     run_as_root = kw.pop('run_as_root', True)
     return processutils.execute(*cmd, run_as_root=run_as_root,
                                 root_helper=root_helper, **kw)
-
-
-def increment_serial(serial=0):
-    # This provides for *roughly* unix timestamp based serial numbers
-    new_serial = timeutils.utcnow_ts()
-
-    if new_serial <= serial:
-        new_serial = serial + 1
-
-    return new_serial
 
 
 def deep_dict_merge(a, b):

--- a/designate/worker/tasks/zone.py
+++ b/designate/worker/tasks/zone.py
@@ -19,11 +19,11 @@ from collections import namedtuple
 import dns
 from oslo_config import cfg
 from oslo_log import log as logging
+from oslo_utils import timeutils
 
 from designate.worker import utils as wutils
 from designate.worker.tasks import base
 from designate import exceptions
-from designate import utils
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
@@ -553,11 +553,10 @@ class RecoverShard(base.Task):
         # Include things that have been hanging out in PENDING
         # status for longer than they should
         # Generate the current serial, will provide a UTC Unix TS.
-        current = utils.increment_serial()
         stale_criterion = {
             'shard': "BETWEEN %s,%s" % (self.begin_shard, self.end_shard),
             'status': 'PENDING',
-            'serial': "<%s" % (current - self.max_prop_time)
+            'serial': "<%s" % (timeutils.utcnow_ts() - self.max_prop_time)
         }
 
         stale_zones = self.storage.find_zones(self.context, stale_criterion)

--- a/setup.cfg
+++ b/setup.cfg
@@ -118,6 +118,7 @@ designate.producer_tasks =
     periodic_exists = designate.producer.tasks:PeriodicExistsTask
     periodic_secondary_refresh = designate.producer.tasks:PeriodicSecondaryRefreshTask
     delayed_notify = designate.producer.tasks:PeriodicGenerateDelayedNotifyTask
+    increment_serial = designate.producer.tasks:PeriodicIncrementSerialTask
     worker_periodic_recovery = designate.producer.tasks:WorkerPeriodicRecovery
 
 designate.heartbeat_emitter =


### PR DESCRIPTION
This patch moves the responsibility of incrementing the serial on a zone from central to the producer. This also means that NOTIFY is triggered by the producer after the serial has been incremented. The advantage of this approach is that we can now batch requests which means less work for the DNS servers, and it removes the risk of
race-conditions when updating the serial. Finally, the producer is sharded and is easy to scale which means that this approach should scale well with many zones.

Backporting https://review.opendev.org/c/openstack/designate/+/871255