### PR TITLE
Allow zone creation in other tenants via policy rule.

### DIFF
--- a/designate/central/service.py
+++ b/designate/central/service.py
@@ -806,7 +806,8 @@ class Service(service.RPCService):
                 zone.parent_zone_id = parent_zone.id
                 # Do subzone policy check instead of regular create_zone
                 policy.check('create_sub_zone', context, target)
-            else:
+            elif not policy.check('create_super_zone', context,
+                                  do_raise=False):
                 raise exceptions.IllegalChildZone('Unable to create '
                                                   'subzone in another '
                                                   'tenants zone')

--- a/designate/central/service.py
+++ b/designate/central/service.py
@@ -806,7 +806,7 @@ class Service(service.RPCService):
                 zone.parent_zone_id = parent_zone.id
                 # Do subzone policy check instead of regular create_zone
                 policy.check('create_sub_zone', context, target)
-            elif not policy.check('create_super_zone', context,
+            elif not policy.check('create_sub_zone_other_project', context,
                                   do_raise=False):
                 raise exceptions.IllegalChildZone('Unable to create '
                                                   'subzone in another '

--- a/designate/tests/functional/central/test_service.py
+++ b/designate/tests/functional/central/test_service.py
@@ -629,7 +629,7 @@ class CentralServiceTest(designate.tests.functional.TestCase):
 
     def test_create_subzone_failure(self):
         # Set the policy to reject subzone creation in other tenants
-        self.policy({'create_super_zone': '!'})
+        self.policy({'create_sub_zone_other_project': '!'})
 
         context = self.get_admin_context()
 
@@ -657,7 +657,7 @@ class CentralServiceTest(designate.tests.functional.TestCase):
 
     def test_create_subzone_in_other_tenants_via_policy(self):
         # Set the policy to allow subzone creation in other tenants
-        self.policy({'create_super_zone': '@'})
+        self.policy({'create_sub_zone_other_project': '@'})
 
         context = self.get_admin_context()
 

--- a/designate/tests/functional/central/test_service.py
+++ b/designate/tests/functional/central/test_service.py
@@ -628,6 +628,9 @@ class CentralServiceTest(designate.tests.functional.TestCase):
         self.assertEqual(parent_zone['id'], subzone['parent_zone_id'])
 
     def test_create_subzone_failure(self):
+        # Set the policy to reject subzone creation in other tenants
+        self.policy({'create_super_zone': '!'})
+
         context = self.get_admin_context()
 
         # Explicitly set a tenant_id
@@ -651,6 +654,36 @@ class CentralServiceTest(designate.tests.functional.TestCase):
                                 context, objects.Zone.from_dict(values))
 
         self.assertEqual(exceptions.IllegalChildZone, exc.exc_info[0])
+
+    def test_create_subzone_in_other_tenants_via_policy(self):
+        # Set the policy to allow subzone creation in other tenants
+        self.policy({'create_super_zone': '@'})
+
+        context = self.get_admin_context()
+
+        # Explicitly set a tenant_id
+        context.project_id = '1'
+
+        # Create the Parent Zone using fixture 0
+        parent_zone = self.create_zone(fixture=0, context=context)
+
+        context = self.get_admin_context()
+
+        # Explicitly use a different tenant_id
+        context.project_id = '2'
+
+        # Prepare values for the subzone using fixture 1 as a base
+        values = self.get_zone_fixture(fixture=1)
+        values['name'] = 'www.%s' % parent_zone['name']
+
+        # Attempt to create the subzone
+        zone = self.central_service.create_zone(
+            context, objects.Zone.from_dict(values))
+
+        # Ensure all values have been set correctly
+        self.assertIsNotNone(zone['id'])
+        self.assertEqual(zone['name'], values['name'])
+        self.assertEqual(zone['email'], values['email'])
 
     def test_create_superzone_failure(self):
         context = self.get_admin_context()

--- a/etc/designate/policy.yaml.sample
+++ b/etc/designate/policy.yaml.sample
@@ -551,6 +551,7 @@
 #"create_zone": "(role:admin and system_scope:all) or (role:member and project_id:%(project_id)s)"
 #"create_sub_zone": "(role:admin and system_scope:all) or (role:member and project_id:%(project_id)s)"
 #"create_super_zone": "(role:admin and system_scope:all) or (role:member and project_id:%(project_id)s)"
+#"create_sub_zone_other_project": "role:admin and system_scope:all"
 
 # DEPRECATED
 # "create_zone":"rule:admin_or_owner" has been deprecated since W in

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,4 @@ oslo.context>=4.0.0 # Apache-2.0
 oslo.policy>=3.7.0 # Apache-2.0
 tooz>=1.58.0 # Apache-2.0
 futurist>=1.2.0 # Apache-2.0
+edgegrid-python>=1.1.1 # Apache-2.0


### PR DESCRIPTION
Allow to create a zone on other tenants via policy `create_super_zone`.