### PR TITLE
Add python-binary-memcached package

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -2,6 +2,7 @@ dumb-init
 jaeger-client
 python-memcached
 pymemcache
+python-binary-memcached
 redis
 raven
 paste


### PR DESCRIPTION
Install the python-binary-memcached package into the Designate image

SALS works only over a binary protocol, and it can only work with bmemcached library, which requires pip package `python-binary-memcached` to be present for keystonemiddleware.

See https://github.com/openstack/keystonemiddleware/commit/667950355129bb04c671c4ceda46d63a9a6b45b0