### PR TITLE
Do not show or allow to get CATALOG zones to non-admins.

### DIFF
--- a/designate/central/service.py
+++ b/designate/central/service.py
@@ -984,10 +984,14 @@ class Service(service.RPCService):
 
         policy.check('find_zones', context, target)
 
-        if 'admin' not in context.roles:
-            if criterion is None:
-                criterion = {}
+        if criterion is None:
+            criterion = {}
+
+        # we completely forbid to look for catalog zones
+        if 'type' not in criterion.keys():
             criterion['type'] = '!CATALOG'
+        elif criterion.get('type') == 'CATALOG':
+            raise exceptions.Forbidden
 
         return self.storage.find_zones(context, criterion, marker, limit,
                                        sort_key, sort_dir)

--- a/designate/tests/functional/api/v2/test_zones.py
+++ b/designate/tests/functional/api/v2/test_zones.py
@@ -357,26 +357,45 @@ class ApiV2ZonesTest(v2.ApiV2TestCase):
         self.client.get(url, status=406, headers={'Accept': 'test/goat',
                                                   'X-Test-Role': 'member'})
 
-    def test_get_catalog_zone(self):
+#NOTE: in ccloud we don't allow to list CATALOG zones at all:
+#    def test_get_catalog_zone(self):
+#        catalog_zone_fixture = self.get_zone_fixture(fixture=4)
+#        catalog_zone = self.storage.create_zone(
+#            self.admin_context, objects.Zone.from_dict(catalog_zone_fixture))
+#
+#        response = self.client.get('/zones/',
+#                                   headers={
+#                                       'Accept': 'application/json',
+#                                       'X-Test-Role': 'admin',
+#                                       'X-Auth-All-Projects': 'True',
+#                                   })
+#        self.assertEqual(catalog_zone.id, response.json['zones'][0]['id'])
+#
+#        response = self.client.get('/zones/%s' % catalog_zone['id'],
+#                                   headers={
+#                                       'Accept': 'application/json',
+#                                       'X-Test-Role': 'admin',
+#                                       'X-Auth-All-Projects': 'True',
+#                                   })
+#        self.assertEqual(catalog_zone.id, response.json['id'])
+
+    def test_get_catalog_zone_admin_forbidden(self):
         catalog_zone_fixture = self.get_zone_fixture(fixture=4)
         catalog_zone = self.storage.create_zone(
             self.admin_context, objects.Zone.from_dict(catalog_zone_fixture))
 
-        response = self.client.get('/zones/',
-                                   headers={
-                                       'Accept': 'application/json',
-                                       'X-Test-Role': 'admin',
-                                       'X-Auth-All-Projects': 'True',
-                                   })
-        self.assertEqual(catalog_zone.id, response.json['zones'][0]['id'])
+        self._assert_exception('forbidden', 403, self.client.get,
+                               '/zones?type=CATALOG',
+                               headers={'X-Test-Role': 'cloud_dns_admin'})
 
-        response = self.client.get('/zones/%s' % catalog_zone['id'],
-                                   headers={
-                                       'Accept': 'application/json',
-                                       'X-Test-Role': 'admin',
-                                       'X-Auth-All-Projects': 'True',
-                                   })
-        self.assertEqual(catalog_zone.id, response.json['id'])
+    def test_get_catalog_zone_member_forbidden(self):
+        catalog_zone_fixture = self.get_zone_fixture(fixture=4)
+        catalog_zone = self.storage.create_zone(
+            self.admin_context, objects.Zone.from_dict(catalog_zone_fixture))
+
+        self._assert_exception('forbidden', 403, self.client.get,
+                               '/zones?type=CATALOG',
+                               headers={'X-Test-Role': 'member'})
 
     def test_get_catalog_zone_no_admin(self):
         catalog_zone_fixture = self.get_zone_fixture(fixture=4)


### PR DESCRIPTION
- Our admin role for dns is cloud_dns_admin
- Raise Forbidden if regular user tries looking for catalog zones