### PR TITLE
Fix-up of catalog zones for ccloud.

### DIFF
--- a/designate/storage/sqlalchemy/__init__.py
+++ b/designate/storage/sqlalchemy/__init__.py
@@ -2483,8 +2483,11 @@ class SQLAlchemyStorage(base.SQLAlchemy):
         return catalog_zone
 
     def get_catalog_zone(self, context, pool):
+        # we need elevated privileges here because only
+        # is_admin:true users are allowed to look up catalog zones:
         catalog_zone = self.find_zone(
-            context, criterion={
+            context.elevated(all_tenants=True),
+            criterion={
                 'pool_id': pool.id, 'type': constants.ZONE_CATALOG})
         return catalog_zone
 


### PR DESCRIPTION
- The catalog zones are explicitely excluded from lookup by default.
- But we still should allow to find those by type=CATALOG to admins.
- We also need to use elevated context and all_tenants when looking for catalog zones. Since catalog zones do not belong to any project.