### PR TITLE
Introduce separate policy check for zone creation in iaas-* Keystone

### DIFF
--- a/designate/api/v2/controllers/zones/__init__.py
+++ b/designate/api/v2/controllers/zones/__init__.py
@@ -99,6 +99,17 @@ class ZonesController(rest.RestController):
             mgmt_email = CONF['service:central'].managed_resource_email
             zone['email'] = mgmt_email
 
+        # Extract domain name for IAAS domain policy checks down in central
+        try:
+            token_info = request.environ['keystone.token_info']
+            token = token_info['token']
+            project_info = token['project']
+            domain_info = project_info['domain']
+            context.project_domain_name = domain_info['name']
+        except KeyError:
+            LOG.error('Not able to find Keystone domain name when '
+                      'creating a zone: %s', zone.name)
+
         # Create the zone
         zone = self.central_api.create_zone(context, zone)
 

--- a/designate/context.py
+++ b/designate/context.py
@@ -35,17 +35,19 @@ class DesignateContext(context.RequestContext):
     _hard_delete = False
     _client_addr = None
     _delete_shares = False
+    _project_domain_name = None
     FROM_DICT_EXTRA_KEYS = [
         'original_project_id', 'service_catalog', 'all_tenants', 'abandon',
         'edit_managed_records', 'tsigkey_id', 'hide_counts', 'client_addr',
-        'hard_delete', 'delete_shares'
+        'hard_delete', 'delete_shares', 'project_domain_name'
     ]
 
     def __init__(self, service_catalog=None, all_tenants=False, abandon=None,
                  tsigkey_id=None, original_project_id=None,
                  edit_managed_records=False, hide_counts=False,
                  client_addr=None, user_auth_plugin=None,
-                 hard_delete=False, delete_shares=False, **kwargs):
+                 hard_delete=False, delete_shares=False,
+                 project_domain_name=None, **kwargs):
         super().__init__(**kwargs)
 
         self.user_auth_plugin = user_auth_plugin
@@ -61,6 +63,7 @@ class DesignateContext(context.RequestContext):
         self.hide_counts = hide_counts
         self.client_addr = client_addr
         self.delete_shares = delete_shares
+        self.project_domain_name = project_domain_name
 
     def deepcopy(self):
         return self.from_dict(self.to_dict())
@@ -98,6 +101,7 @@ class DesignateContext(context.RequestContext):
             'hide_counts': self.hide_counts,
             'client_addr': self.client_addr,
             'delete_shares': self.delete_shares,
+            'project_domain_name': self.project_domain_name,
         })
 
         return copy.deepcopy(d)
@@ -207,6 +211,14 @@ class DesignateContext(context.RequestContext):
     @delete_shares.setter
     def delete_shares(self, value):
         self._delete_shares = value
+
+    @property
+    def project_domain_name(self):
+        return self._project_domain_name
+
+    @project_domain_name.setter
+    def project_domain_name(self, value):
+        self._project_domain_name = value
 
     def get_auth_plugin(self):
         if self.user_auth_plugin:

--- a/designate/tests/functional/central/test_basic.py
+++ b/designate/tests/functional/central/test_basic.py
@@ -168,7 +168,8 @@ class CentralBasic(designate.tests.functional.TestCase):
             'abandon',
             'all_tenants',
             'hard_delete',
-            'project_id'
+            'project_id',
+            'project_domain_name'
         ])
 
 


### PR DESCRIPTION
domains.

- Special case for allowing direct zone creation in iaas-* domains.
- The domain name is extracted from the request in the API.
- This name is then passed to central via context allowing to determine if a different policy rule should apply when creating a zone or a sub-zone.