### PR TITLE
Fix zone scheduling to non default pool for iaas-* domains.

### DIFF
--- a/designate/scheduler/filters/attribute_filter.py
+++ b/designate/scheduler/filters/attribute_filter.py
@@ -16,6 +16,7 @@ from oslo_utils.strutils import bool_from_string
 
 from designate import policy
 from designate import exceptions
+from designate.common import constants
 from designate.objects import PoolList
 from designate.scheduler.filters import base
 
@@ -57,6 +58,13 @@ class AttributeFilter(base.Filter):
     """
 
     def filter(self, context, pools, zone):
+
+        # Get Domain name to handle IAAS domains differently
+        if context.project_domain_name:
+            domain_name = context.project_domain_name.lower()
+        else:
+            domain_name = ''
+
         try:
             # if pool_id was given - schedule there
             pool_id = zone.attributes.get('pool_id')
@@ -65,7 +73,20 @@ class AttributeFilter(base.Filter):
                     pool = self.storage.get_pool(context, pool_id)
                 except Exception:
                     return PoolList()
-                policy.check('zone_create_forced_pool', context, pool)
+
+                if domain_name.startswith('iaas'):
+                    # Special case - IAAS Keystone Domains
+                    if policy.enforce_new_defaults():
+                        target = {constants.RBAC_PROJECT_ID: zone.tenant_id}
+                    else:
+                        target = {'tenant_id': zone.tenant_id}
+                    policy.check('iaas_zone_create_forced_pool',
+                                 context,
+                                 target)
+                else:
+                    # All other Keystone Domains apply default rule
+                    policy.check('zone_create_forced_pool', context, pool)
+
                 if pool in pools:
                     pools = PoolList()
                     pools.append(pool)

--- a/designate/scheduler/filters/pool_id_attribute_filter.py
+++ b/designate/scheduler/filters/pool_id_attribute_filter.py
@@ -16,6 +16,7 @@ from oslo_log import log as logging
 from designate import exceptions
 from designate import objects
 from designate import policy
+from designate.common import constants
 from designate.scheduler.filters import base
 
 LOG = logging.getLogger(__name__)
@@ -65,6 +66,11 @@ class PoolIDAttributeFilter(base.Filter):
             containing a single pool.
         :raises: Forbidden, PoolNotFound
         """
+        # Get Domain name to handle IAAS domains differently
+        if context.project_domain_name:
+            domain_name = context.project_domain_name.lower()
+        else:
+            domain_name = ''
 
         try:
             if zone.attributes.get('pool_id'):
@@ -73,7 +79,19 @@ class PoolIDAttributeFilter(base.Filter):
                     pool = self.storage.get_pool(context, pool_id)
                 except Exception:
                     return objects.PoolList()
-                policy.check('zone_create_forced_pool', context, pool)
+
+                if domain_name.startswith('iaas'):
+                    # Special case - IAAS Keystone Domains
+                    if policy.enforce_new_defaults():
+                        target = {constants.RBAC_PROJECT_ID: zone.tenant_id}
+                    else:
+                        target = {'tenant_id': zone.tenant_id}
+                    policy.check('iaas_zone_create_forced_pool',
+                                 context,
+                                 target)
+                else:
+                    # All other Keystone Domains apply default rule
+                    policy.check('zone_create_forced_pool', context, pool)
                 if pool in pools:
                     pools = objects.PoolList()
                     pools.append(pool)

--- a/designate/tests/unit/scheduler/test_filters.py
+++ b/designate/tests/unit/scheduler/test_filters.py
@@ -33,6 +33,7 @@ class SchedulerFilterTest(oslotest.base.BaseTestCase):
     def setUp(self):
         super().setUp()
         self.context = mock.Mock()
+        self.context.project_domain_name = 'test'
         self.zone = objects.Zone(
             name='example.com.',
             type='PRIMARY',


### PR DESCRIPTION
Like with zone creation, we need to check different policy when a zone is scheduled to a non-default pool in iaas-* Keystone domain via attributes.

New policy check is called 'iaas_zone_create_forced_pool'