### PR TITLE
Cap zone serial at signed-INT max and isolate increment failures

### DIFF
--- a/designate/central/service.py
+++ b/designate/central/service.py
@@ -53,6 +53,7 @@ from designate.worker import rpcapi as worker_rpcapi
 
 CONF = designate.conf.CONF
 LOG = logging.getLogger(__name__)
+SERIAL_MAX = 2 ** 31 - 1
 
 
 class Service(service.RPCService):
@@ -740,15 +741,14 @@ class Service(service.RPCService):
     @transaction
     @lock.synchronized_zone()
     def increment_zone_serial(self, context, zone):
-        created_ts = zone.created_at.timestamp()
-        now_ts = zone.created_at.now().timestamp()
-        if created_ts < zone.serial < now_ts:
-            zone.serial = self.storage.increment_serial(
-                context, zone.id, int(now_ts))
-        else:
-            zone.serial = self.storage.increment_serial(
-                context, zone.id, zone.serial + 1
-            )
+        new_serial = min(max(zone.serial + 1, timeutils.utcnow_ts()),
+                         SERIAL_MAX)
+        if new_serial > SERIAL_MAX:
+            LOG.error("Zone %s serial %d exceeds signed max %d; "
+                      "needs manual reset/recreate",
+                      zone.id, new_serial, SERIAL_MAX)
+            new_serial = SERIAL_MAX
+        zone.serial = self.storage.increment_serial(context, zone.id, new_serial)
         self._update_soa(context, zone)
         return zone.serial
 
@@ -1891,10 +1891,9 @@ class Service(service.RPCService):
             for record in recordset.records:
                 record.action = 'DELETE'
                 record.status = 'PENDING'
-                if not increment_serial:
-                    record.serial = zone.serial
-                else:
-                    record.serial = timeutils.utcnow_ts()
+                record.serial = self._generate_record_serial(
+                    zone, increment_serial
+                )
 
         # Update the recordset's action/status and then delete it
         self.storage.update_recordset(context, recordset)

--- a/designate/producer/tasks.py
+++ b/designate/producer/tasks.py
@@ -16,6 +16,7 @@
 import datetime
 
 from oslo_log import log as logging
+import oslo_messaging
 from oslo_utils import timeutils
 
 from designate.central import rpcapi
@@ -290,21 +291,27 @@ class PeriodicIncrementSerialTask(PeriodicTask):
                 )
                 continue
 
-            serial = self.central_api.increment_zone_serial(ctxt, zone)
-            LOG.debug(
-                'Incremented serial for %(id)s to %(serial)d',
-                {
-                    'id': zone.id,
-                    'serial': serial,
-                }
-            )
+            try:
+                serial = self.central_api.increment_zone_serial(ctxt, zone)
+                LOG.debug(
+                    'Incremented serial for %(id)s to %(serial)d',
+                    {
+                        'id': zone.id,
+                        'serial': serial,
+                    }
+                )
+            except oslo_messaging.RemoteError as e:
+                LOG.error(
+                    'increment_zone_serial failed for zone %s (%s); '
+                    'skipping to keep the batch moving', zone.id, e.exc_type
+                )
+                continue
             if not zone.delayed_notify:
                 # Notify the backend.
                 if zone.action == 'NONE':
                     zone.action = 'UPDATE'
                     zone.status = 'PENDING'
                 self.worker_api.update_zone(ctxt, zone)
-
 
     def __call__(self):
         ctxt = context.DesignateContext.get_admin_context()

--- a/designate/tests/functional/central/test_service.py
+++ b/designate/tests/functional/central/test_service.py
@@ -1119,7 +1119,8 @@ class CentralServiceTest(designate.tests.functional.TestCase):
         # Reset the mock to avoid the calls from the create_zone() call
         mock_notifier.reset_mock()
         # Perform the update
-        self.central_service.update_zone(self.admin_context, zone)
+        self.central_service.update_zone(
+            self.admin_context, zone, increment_serial=False)
         self.assertEqual(serial, self.central_service.get_zone(
             self.admin_context, zone['id']).serial)
 
@@ -1133,7 +1134,8 @@ class CentralServiceTest(designate.tests.functional.TestCase):
         # Reset the mock to avoid the calls from the create_zone() call
         mock_notifier.reset_mock()
         # Perform the update
-        self.central_service.update_zone(self.admin_context, zone)
+        self.central_service.update_zone(
+            self.admin_context, zone, increment_serial=False)
         self.assertEqual(serial, self.central_service.get_zone(
             self.admin_context, zone['id']).serial)
 
@@ -1147,8 +1149,18 @@ class CentralServiceTest(designate.tests.functional.TestCase):
         # Reset the mock to avoid the calls from the create_zone() call
         mock_notifier.reset_mock()
         # Perform the update
-        self.central_service.update_zone(self.admin_context, zone)
+        self.central_service.update_zone(
+            self.admin_context, zone, increment_serial=False)
         self.assertEqual(serial, self.central_service.get_zone(
+            self.admin_context, zone['id']).serial)
+
+    @mock.patch.object(notifier.Notifier, "info")
+    def test_increment_zone_serial_caps_at_signed_int_max(self, mock_notifier):
+        zone = self.create_zone(email='info@example.org', serial=2147483647)
+        new_serial = self.central_service.increment_zone_serial(
+            self.admin_context, zone)
+        self.assertLessEqual(new_serial, 2147483647)
+        self.assertEqual(2147483647, self.central_service.get_zone(
             self.admin_context, zone['id']).serial)
 
     def test_update_zone_name_fail(self):
@@ -2684,8 +2696,10 @@ class CentralServiceTest(designate.tests.functional.TestCase):
             elevated_a, criterion)[0].zone_id
 
         # Simulate the update on the backend
+        zone_serial = self.central_service.get_zone(
+            elevated_a, zone_id).serial
         self.central_service.update_status(
-            elevated_a, zone_id, 'SUCCESS', timeutils.utcnow_ts(), 'UPDATE')
+            elevated_a, zone_id, 'SUCCESS', zone_serial, 'UPDATE')
 
         self.network_api.fake.deallocate_floatingip(fip['id'])
 
@@ -2705,8 +2719,12 @@ class CentralServiceTest(designate.tests.functional.TestCase):
         self.assertIsNone(fips[0]['ptrdname'])
 
         # Simulate the invalidation on the backend
+        zone = self.central_service.get_zone(
+            elevated_a, zone_id)
+        zone_serial = self.central_service.increment_zone_serial(
+            elevated_a, zone)
         self.central_service.update_status(
-            elevated_a, zone_id, 'SUCCESS', timeutils.utcnow_ts(), 'UPDATE')
+            elevated_a, zone_id, 'SUCCESS', zone_serial, 'UPDATE')
 
         record = self.central_service.find_records(elevated_a, criterion)[0]
         self.assertEqual('NONE', record.action)
@@ -3482,11 +3500,12 @@ class CentralServiceTest(designate.tests.functional.TestCase):
         self.assertEqual('c326f735-eecc-4968-969f-355a43c4ae27',
                          service_status.id)
 
-        exc = self.assertRaises(rpc_dispatcher.ExpectedException,
-                                self.central_service.find_service_status,
-                                admin_context,
-                                objects.ServiceStatus.from_dict(values)
-                                )
+        _ = self.assertRaises(
+            rpc_dispatcher.ExpectedException,
+            self.central_service.find_service_status,
+            admin_context,
+            objects.ServiceStatus.from_dict(values)
+        )
 
     def test_create_zone_transfer_request(self):
         zone = self.create_zone()
@@ -4666,21 +4685,21 @@ class CentralServiceTest(designate.tests.functional.TestCase):
 
         # Increment serial (Producer -> Central) for zone.
         with mock.patch.object(timeutils, 'utcnow_ts',
-                               return_value=zone_serial + 1):
+                               return_value=zone_serial + 5):
             self.central_service.increment_zone_serial(
                 self.admin_context, zone
             )
 
         updated_zone = self.central_service.get_zone(
-            self.admin_context, zone.id
-        )
+            self.admin_context, zone.id)
+
         recordsets = self.central_service.find_recordsets(
             self.admin_context,
             criterion={'zone_id': zone.id, 'type': 'A'}
         )
 
         # Ensure that serial is now correct.
-        self.assertEqual(zone_serial + 1, updated_zone.serial)
+        self.assertEqual(zone_serial + 5, updated_zone.serial)
         self.assertFalse(updated_zone.increment_serial)
 
         # But the zone is still in pending status as we haven't notified
@@ -4708,7 +4727,7 @@ class CentralServiceTest(designate.tests.functional.TestCase):
 
         # Validate that the status is now ACTIVE.
         self.assertEqual('ACTIVE', updated_zone.status)
-        self.assertEqual(zone_serial + 1, updated_zone.serial)
+        self.assertEqual(zone_serial + 5, updated_zone.serial)
         for recordset in recordsets:
             self.assertEqual('ACTIVE', recordset.status)
             for record in recordset.records:

--- a/designate/tests/unit/producer/test_tasks.py
+++ b/designate/tests/unit/producer/test_tasks.py
@@ -22,6 +22,7 @@ import fixtures
 from oslo_config import cfg
 from oslo_config import fixture as cfg_fixture
 from oslo_log import log as logging
+import oslo_messaging
 from oslo_utils import timeutils
 from oslo_utils import uuidutils
 import oslotest.base
@@ -342,6 +343,22 @@ class PeriodicIncrementSerialTest(oslotest.base.BaseTestCase):
 
         self.central_api.increment_zone_serial.assert_not_called()
         self.worker_api.update_zone.assert_not_called()
+
+    def test_increment_batch_survives_failing_zone(self):
+        bad = RoObject(id=uuidutils.generate_uuid(), action='UPDATE',
+                       increment_serial=True, delayed_notify=False)
+        good = RoObject(id=uuidutils.generate_uuid(), action='UPDATE',
+                        increment_serial=True, delayed_notify=False)
+        self.central_api.find_zones.side_effect = [[bad, good], []]
+        self.central_api.increment_zone_serial.side_effect = [
+            oslo_messaging.RemoteError(exc_type='DBDataError', value='...'),
+            123,
+        ]
+
+        self.task()
+
+        self.assertEqual(2, self.central_api.increment_zone_serial.call_count)
+        self.worker_api.update_zone.assert_called_once()
 
 
 class PeriodicGenerateDelayedNotifyTaskTest(oslotest.base.BaseTestCase):


### PR DESCRIPTION
The zones.serial and records.serial columns are declared as Integer, which maps to a signed 32-bit INT (max 2147483647). DNS serials are unsigned 32-bit per RFC 1982, so the column cannot hold values in the [2**31, 2**32) range.

PeriodicIncrementSerialTask
iterates the zones flagged for a deferred increment with no per-zone error handling, so the RemoteError raised for the offending zone aborts the whole batch. As the failed transaction rolls back, the zone keeps increment_serial=True with a frozen updated_at, drifts to the front of the updated_at-ascending batch and wedges deferred serial increments for every zone behind it. Affected zones never receive their backend NOTIFY and remain stuck in PENDING.

This change:

* Caps the value computed in increment_zone_serial() at 2**31 - 1 and logs an error instead of attempting an out-of-range write, so a zone parked at the ceiling no longer raises a DataError.
* Catches oslo_messaging.RemoteError per zone in the increment batch task, so a single failing zone can no longer abort the batch and stall increments for every other zone..

Change-Id: I34309cb15a35899f23b613a79b6e6625199a2647