### PR TITLE
Use own keystoneauth fork with support for HTTP 429

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -10,4 +10,4 @@ git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middle
 git+https://github.com/sapcc/openstack-audit-middleware.git@master#egg=audit-middleware
 git+https://github.com/sapcc/dnspython.git@stable/2024.2-m3#egg=dnspython
 git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
-git+https://github.com/sapcc/keystonemiddleware.git@stable/2024.2-m3#egg=keystonemiddleware
+git+https://github.com/sapcc/keystoneauth.git@stable/2024.2-m3#egg=keystoneauth1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ Flask!=0.11,>=0.10 # BSD
 greenlet>=0.4.15 # MIT
 Jinja2>=2.10 # BSD License (3 clause)
 jsonschema>=3.2.0 # MIT
-keystoneauth1>=3.4.0 # Apache-2.0
 keystonemiddleware>=4.17.0 # Apache-2.0
 openstacksdk>=0.103.0 # Apache-2.0
 oslo.config>=6.8.0 # Apache-2.0


### PR DESCRIPTION
- related to https://bugs.launchpad.net/keystoneauth/+bug/2157013
- and fork of `keystonemiddleware` we don't actually use.