### PR TITLE
Fix zone move between pools (backport)

### DIFF
--- a/designate/central/service.py
+++ b/designate/central/service.py
@@ -431,7 +431,7 @@ class Service(service.RPCService):
 
         return ns
 
-    def _add_ns(self, context, zone, ns_record):
+    def _add_ns(self, context, zone, ns_record, increment_serial=True):
         # Get NS recordset
         # If the zone doesn't have an NS recordset yet, create one
         try:
@@ -452,10 +452,14 @@ class Service(service.RPCService):
             objects.Record(data=ns_record, managed=True)
         )
 
-        self._update_recordset_in_storage(context, zone, recordset,
-                                          set_delayed_notify=True)
+        # Intentional: delayed notify is tied to increment_serial so
+        # callers that skip the serial bump also skip the notification.
+        self._update_recordset_in_storage(
+            context, zone, recordset,
+            increment_serial=increment_serial,
+            set_delayed_notify=increment_serial)
 
-    def _delete_ns(self, context, zone, ns_record):
+    def _delete_ns(self, context, zone, ns_record, increment_serial=True):
         recordset = self.find_recordset(
             context,
             criterion={
@@ -469,8 +473,12 @@ class Service(service.RPCService):
             if record.data == ns_record:
                 recordset.records.remove(record)
 
-        self._update_recordset_in_storage(context, zone, recordset,
-                                          set_delayed_notify=True)
+        # Intentional: delayed notify is tied to increment_serial so
+        # callers that skip the serial bump also skip the notification.
+        self._update_recordset_in_storage(
+            context, zone, recordset,
+            increment_serial=increment_serial,
+            set_delayed_notify=increment_serial)
 
     # Quota Enforcement Methods
     def _enforce_zone_quota(self, context, tenant_id):
@@ -1464,24 +1472,28 @@ class Service(service.RPCService):
         create_ns = target_ns.difference(orig_ns)
         delete_ns = orig_ns.difference(target_ns)
 
-        # Update target NS servers for the zone
+        # Update target NS servers for the zone without triggering serial
+        # increments or delayed notifications; the pool move handles the
+        # zone update itself at the end of this method.
         for ns_record in create_ns:
-            self._add_ns(elevated_context, zone, ns_record)
+            self._add_ns(elevated_context, zone, ns_record,
+                         increment_serial=False)
 
         # Then handle the ns_records to delete
         for ns_record in delete_ns:
-            self._delete_ns(elevated_context, zone, ns_record)
-
-        zone = self._update_zone_in_storage(
-                context, zone, increment_serial=False)
+            self._delete_ns(elevated_context, zone, ns_record,
+                            increment_serial=False)
 
         LOG.info("Moving zone '%(zone)s' to pool '%(pool)s'",
                  {'zone': zone.name, 'pool': target_pool_id})
         zone.pool_id = target_pool_id
+        zone = self._update_zone_in_storage(
+                context, zone, increment_serial=False)
+
         zone.refresh = self._generate_soa_refresh_interval()
-        zone.action = 'CREATE'
-        zone.status = 'PENDING'
-        self.worker_api.create_zone(context, zone)
+        zone.action = constants.UPDATE
+        zone.status = constants.PENDING
+        self.worker_api.update_zone(context, zone)
 
         return zone
 

--- a/designate/tests/functional/__init__.py
+++ b/designate/tests/functional/__init__.py
@@ -707,12 +707,17 @@ class TestCase(base.BaseTestCase):
         context = kwargs.pop('context', self.admin_context)
         fixture = kwargs.pop('fixture', 0)
         zone_type = kwargs.pop('type', None)
+        pool_id = kwargs.get('pool_id')
 
         values = self.get_zone_fixture(zone_type=zone_type,
                                        fixture=fixture, values=kwargs)
 
         if 'tenant_id' not in values:
             values['tenant_id'] = context.project_id
+
+        if pool_id:
+            values['attributes'] = values.get('attributes', {})
+            values['attributes']['pool_id'] = pool_id
 
         return self.central_service.create_zone(
             context, objects.Zone.from_dict(values))

--- a/designate/tests/functional/central/test_service.py
+++ b/designate/tests/functional/central/test_service.py
@@ -4401,6 +4401,33 @@ class CentralServiceTest(designate.tests.functional.TestCase):
         self.assertEqual(zone.id, moved_zone.id)
         self.assertEqual(moved_zone.pool_id, second_pool['id'])
 
+    def test_pool_move_zone_from_non_default_to_default_pool(self):
+        # create 2 pools
+        pool = self.create_pool(fixture=0)
+        second_pool = self.create_pool(fixture=1)
+
+        self.config(scheduler_filters=['pool_id_attribute'],
+                    group='service:central')
+
+        zone = self.create_zone(context=self.admin_context,
+                                pool_id=second_pool.id)
+        self.storage.create_pool_ns_record(
+            self.admin_context, pool['id'],
+            objects.PoolNsRecord(priority=1, hostname='ns-old.example.org.')
+        )
+
+        self.storage.create_pool_ns_record(
+            self.admin_context, second_pool['id'],
+            objects.PoolNsRecord(priority=1, hostname='ns-new.example.org.')
+        )
+
+        self.central_service.pool_move_zone(self.admin_context,
+            zone.id, pool['id'])
+        moved_zone = self.central_service.get_zone(
+            self.admin_context, zone.id
+        )
+        self.assertEqual(moved_zone.pool_id, pool['id'])
+
     def test_pool_move_zone_no_valid_pool_selected(self):
         pool_id = '794ccc2c-d751-44fe-b57f-8894c9f5c842'
         zone = self.create_zone(fixture=0, pool_id=pool_id)

--- a/releasenotes/notes/fix-zone-move-target-pool-id-41d5a95d0dcb2ede.yaml
+++ b/releasenotes/notes/fix-zone-move-target-pool-id-41d5a95d0dcb2ede.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug that didn't allow zones to be moved from non-default pools to
+    default pools.


### PR DESCRIPTION
Backports two upstream fixes for moving zones between pools:

- 942576 "Fix pool move zone target pool id": pool_move_zone assigned target_pool_id only after writing the zone to storage, so the zone was never actually moved. Set pool_id before the storage update and use update_zone with UPDATE/PENDING instead of create_zone.

- 986096 "Skip serial increments for NS changes during pool move": _add_ns and _delete_ns each triggered a serial increment and delayed notification. Add an increment_serial parameter and pass False from pool_move_zone to avoid redundant serial bumps and notifications.

Includes the upstream functional test and release note.

Upstream-Change-Id: I467435fc07be00757269911b467478c2dd188350
Upstream-Change-Id: I02a75c3855c80ca97d7c31bc08126d0b00eed909

Closes-Bug: #2096866
Closes-Bug: #2150425